### PR TITLE
Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# builds
+*.pd_linux
+*.pd_darwin
+*.dll
+*.o
+*.so
+*.dylib
+
+# macOS
+.DS_Store
+

--- a/examples/01-sine_test.pd
+++ b/examples/01-sine_test.pd
@@ -192,8 +192,6 @@ of 100 elements;
 ;
 #X text 502 91 9) set a test target data array (found in [pd data_arrays])
 ;
-#X text 504 260 11) send an increnting ramp and see the output of the
-network in the array to the right;
 #X text 502 433 12) or test the network manually and check its output
 in the vertical slider below;
 #X text 504 713 13) when done \, destroy the network (it will also
@@ -219,25 +217,27 @@ to its outlets);
 #X obj 505 371 s sine_example;
 #X obj 505 512 s sine_example;
 #X obj 47 613 r sine_example;
+#X text 504 260 11) send an incrementing ramp and see the output of
+the network in the array to the right;
 #X connect 0 0 4 0;
 #X connect 0 2 3 0;
 #X connect 0 4 2 0;
 #X connect 0 5 1 0;
-#X connect 5 0 39 0;
-#X connect 6 0 45 0;
-#X connect 7 0 44 0;
-#X connect 8 0 46 0;
-#X connect 12 0 50 0;
+#X connect 5 0 38 0;
+#X connect 6 0 44 0;
+#X connect 7 0 43 0;
+#X connect 8 0 45 0;
+#X connect 12 0 49 0;
 #X connect 13 0 24 0;
 #X connect 15 0 18 0;
 #X connect 16 0 17 0;
-#X connect 17 0 51 0;
-#X connect 19 0 41 0;
-#X connect 20 0 42 0;
-#X connect 22 0 43 0;
+#X connect 17 0 50 0;
+#X connect 19 0 40 0;
+#X connect 20 0 41 0;
+#X connect 22 0 42 0;
 #X connect 24 0 12 0;
-#X connect 33 0 49 0;
-#X connect 35 0 40 0;
+#X connect 32 0 48 0;
+#X connect 34 0 39 0;
+#X connect 36 0 46 0;
 #X connect 37 0 47 0;
-#X connect 38 0 48 0;
-#X connect 52 0 0 0;
+#X connect 51 0 0 0;

--- a/examples/02-xor_test.pd
+++ b/examples/02-xor_test.pd
@@ -110,8 +110,6 @@ desired output concatenated together as a single list.;
 #X msg 47 437 set_epochs 1500;
 #X text 46 618 7) train the model with 10% of the samples kept for
 validating;
-#X text 483 121 8) validate the model (check the number atoms connected
-to its outlets);
 #X text 482 231 9) Generate random input data to test how well the
 net has learned XOR (check the two toggles below), f 35;
 #X text 483 463 10) destroy when done;
@@ -119,6 +117,8 @@ net has learned XOR (check the two toggles below), f 35;
 It is a simple example of the exclusive-or (XOR) function.;
 #X text 45 492 6) Generate training data (will stop at 3000 samples)
 ;
+#X text 483 121 8) validate the model (check the number of atoms connected
+to its outlets);
 #X connect 0 0 31 0;
 #X connect 0 2 3 0;
 #X connect 0 4 2 0;

--- a/examples/03-mouse_input.pd
+++ b/examples/03-mouse_input.pd
@@ -452,12 +452,6 @@ the four corners of the monitor. A bang is sent out the outlet when
 done \, which also sends the "shuffle_train_set" to [neuralnet]. If
 you want to start this process from the beginning \, make sure to first
 click on "clear" below \, to clear the stored parameters;
-#X text 44 623 8) set a desired minimum accuracy if you want to be
-able to retraing the model without repeating the process in step 9
-;
-#X text 473 672 14) validate the network with 10% of the training data
-set. check the number atoms connected to the outlets of [neuralnet]
-to see if they change;
 #X text 474 775 15) start polling the mouse;
 #X text 941 143 16) turn the DSP on and turn up the volume in the slider
 to hear the results;
@@ -493,31 +487,21 @@ up in this setting. I also usually make sure the three parameters (carrier
 four groups (meaning that the carrier value of the first group is not
 close to the carrier value of any other group \, they should have some
 difference of more than 10).;
-#X text 43 216 While a largeer dataset (more iterations per group)
-produces a low loss \, the accuracy was hard to raise \, and was only
-raised when I made the training dataset smaller. You are free to experiment
+#X floatatom 44 355 5 0 0 0 - - - 0;
+#X msg 44 377 set_accuracy_denominator \$1;
+#X obj 44 400 s mouse_input_example;
+#X text 43 216 While a larger dataset (more iterations per group) produces
+a low loss \, the accuracy was hard to raise \, and was only raised
+when I made the training dataset smaller. You are free to experiment
 with different datasets to see if you can get better results. If you're
 fine with the results \, but the accuracy is still not satisfactory
 \, you can reduce the accuracy denominator with the message below \,
 which will make [neuralnet] more tolerant and will output a higher
 accuracy.;
-#X floatatom 44 355 5 0 0 0 - - - 0;
-#X msg 44 377 set_accuracy_denominator \$1;
-#X obj 44 400 s mouse_input_example;
+#X connect 1 0 2 0;
 #X connect 2 0 3 0;
-#X connect 3 0 4 0;
 #X restore 1191 921 pd some_notes;
 #X msg 533 618 keep_training;
-#X text 472 451 13) in case you have set a desired accuracy \, and
-the accuracy of [neuralnet] has not reached it \, the training dataset
-will not be erased from its memory. If you want to change some parameters
-and retrain the network \, first change any parameters you want \,
-and then send "retrain" to traing from scratch \, or "keep_training"
-to start over without resetting the weights and biases. Otherwise \,
-if you still want to move on with validating and making predictions
-\, send the "release_mem" message first. If you haven't set a desired
-accuracy \, don't send any of these messages \, as Pd will most likely
-crash;
 #X text 49 20 This example uses the mouse coordinates to control three
 parameters in a simple FM patch. It uses [mousestate] from the Cyclone
 library.;
@@ -555,6 +539,21 @@ first destroyed the network \, if you have already created one);
 #X connect 14 0 11 0;
 #X connect 15 0 5 0;
 #X restore 901 517 pd save_and_load;
+#X text 44 623 8) set a desired minimum accuracy if you want to be
+able to retrain the model without repeating the process in step 9;
+#X text 472 450 13) in case you have set a desired accuracy \, and
+the accuracy of [neuralnet] has not reached it \, the training dataset
+will not be erased from its memory. If you want to change some parameters
+and retrain the network \, first change any parameters you want \,
+and then send "retrain" to train from scratch \, or "keep_training"
+to start over without resetting the weights and biases. Otherwise \,
+if you still want to move on with validating and making predictions
+\, send the "release_mem" message first. If you haven't set a desired
+accuracy \, don't send any of these messages \, as Pd will most likely
+crash;
+#X text 473 672 14) validate the network with 10% of the training data
+set. check the number of atoms connected to the outlets of [neuralnet]
+to see if they change;
 #X connect 3 0 39 0;
 #X connect 4 0 39 0;
 #X connect 5 0 65 0;
@@ -616,8 +615,8 @@ first destroyed the network \, if you have already created one);
 #X connect 84 0 86 1;
 #X connect 85 0 31 0;
 #X connect 86 0 85 0;
-#X connect 98 0 79 0;
-#X connect 100 0 66 0;
-#X connect 101 0 67 0;
-#X connect 102 0 60 0;
-#X connect 104 0 79 0;
+#X connect 96 0 79 0;
+#X connect 98 0 66 0;
+#X connect 99 0 67 0;
+#X connect 100 0 60 0;
+#X connect 102 0 79 0;

--- a/examples/04-fashion_mnist.pd
+++ b/examples/04-fashion_mnist.pd
@@ -284,8 +284,6 @@ for classification than the default which is 0.1);
 #X text 463 180 9) train the model;
 #X text 465 259 10) load the validation data (below point 2 \, wait
 for a done message in Pd's console) and then validate the model;
-#X text 462 351 11) send numbers from 0 to 9 and look at the output
-of the left outlet of [neuralnet](the numbers should match);
 #X text 462 494 12) save your model if you want \, or load an existing
 model;
 #X text 461 548 13) destroy the network;
@@ -304,6 +302,8 @@ output from the left outlet \, send "predict_to outlet". when you send
 "confidences 1" \, the "confidence_thresh" message has no effect.;
 #X obj 464 655 neuralnet 784 128 128 10;
 #X msg 464 41 set_epochs 5;
+#X text 462 351 11) send numbers from 0 to 9 and look at the output
+of the left outlet of [neuralnet] (the numbers should match);
 #X connect 1 0 53 0;
 #X connect 2 0 54 0;
 #X connect 6 0 48 0;
@@ -331,11 +331,11 @@ output from the left outlet \, send "predict_to outlet". when you send
 #X connect 42 0 55 0;
 #X connect 43 0 0 0;
 #X connect 44 0 49 0;
-#X connect 57 0 76 0;
-#X connect 76 0 33 0;
-#X connect 76 1 30 0;
-#X connect 76 2 9 0;
-#X connect 76 3 5 0;
-#X connect 76 4 4 0;
-#X connect 76 5 3 0;
-#X connect 77 0 52 0;
+#X connect 57 0 75 0;
+#X connect 75 0 33 0;
+#X connect 75 1 30 0;
+#X connect 75 2 9 0;
+#X connect 75 3 5 0;
+#X connect 75 4 4 0;
+#X connect 75 5 3 0;
+#X connect 76 0 52 0;

--- a/examples/05-accelerometer_input.pd
+++ b/examples/05-accelerometer_input.pd
@@ -581,9 +581,6 @@ parameters;
 #X text 475 350 11) train the network. the argument is percentage of
 data to be used for validating. in this case we'll use 10% of the data
 to validate the model;
-#X text 473 660 13) validate the network with 10% of the training data
-set. check the number atoms connected to the outlets of [neuralnet]
-to see if they change;
 #X text 515 821 14) turn the DSP on and turn up the volume in the slider
 to hear the results;
 #X obj 901 12 r accel_vals;
@@ -624,12 +621,15 @@ Set the first two arguments to [clip] and the [map] abstraction accordingly
 the accuracy of [neuralnet] has not reached it \, the training dataset
 will not be erased from its memory. If you want to change some parameters
 and retrain the network \, first change any parameters you want \,
-and then send "retrain" to traing from scratch \, or "keep_training"
+and then send "retrain" to train from scratch \, or "keep_training"
 to start over without resetting the weights and biases. Otherwise \,
 if you still want to move on with validating and making predictions
 \, send the "release_mem" message first. If you haven't set a desired
 accuracy \, don't send any of these messages \, as Pd will most likely
 crash;
+#X text 473 660 13) validate the network with 10% of the training data
+set. check the number of atoms connected to the outlets of [neuralnet]
+to see if they change;
 #X connect 4 0 50 0;
 #X connect 5 0 50 0;
 #X connect 6 0 74 0;
@@ -643,7 +643,7 @@ crash;
 #X connect 16 0 62 0;
 #X connect 18 0 63 0;
 #X connect 20 0 64 0;
-#X connect 22 0 83 0;
+#X connect 22 0 82 0;
 #X connect 23 0 22 1;
 #X connect 24 0 61 0;
 #X connect 26 0 28 0;
@@ -673,14 +673,14 @@ crash;
 #X connect 53 4 57 0;
 #X connect 58 0 7 0;
 #X connect 59 0 44 0;
-#X connect 76 0 88 0;
-#X connect 82 0 22 0;
-#X connect 83 0 72 0;
-#X connect 88 0 53 0;
-#X connect 88 2 2 0;
-#X connect 88 4 1 0;
-#X connect 88 5 0 0;
-#X connect 91 0 67 0;
-#X connect 92 0 66 0;
-#X connect 93 0 65 0;
-#X connect 94 0 70 0;
+#X connect 76 0 87 0;
+#X connect 81 0 22 0;
+#X connect 82 0 72 0;
+#X connect 87 0 53 0;
+#X connect 87 2 2 0;
+#X connect 87 4 1 0;
+#X connect 87 5 0 0;
+#X connect 90 0 67 0;
+#X connect 91 0 66 0;
+#X connect 92 0 65 0;
+#X connect 93 0 70 0;

--- a/neuralnet-help.pd
+++ b/neuralnet-help.pd
@@ -76,9 +76,6 @@ is .ann);
 #X restore 523 193 pd saving_and_loading_models_messages;
 #X text 35 173 \$1: number of neurons in input layer;
 #X text 35 189 \$2: number of neurons in first hidden layer (N);
-#X text 35 205 \$3: if this is the last argument it is the nubmer of
-neurons in the output layer \, otherwise it is the number of neurons
-in N+1 hidden layer;
 #X text 35 255 ...;
 #X text 35 283 $<N+2>: number of neurons in the output layer (unless
 there are only three arguments \, in any case \, the last argument
@@ -142,23 +139,19 @@ requirements of "desired_loss" and "desired_accuracy" respectively
 ;
 #X text 664 436 Retrains the network when the "desired_loss" or "desired_accuracy"
 messages have been sent (use this and not "train");
-#X text 745 335 Set an accuracy threshold \, where \, if the accuracy
-of the network is below it after training is done \, the training dataset
-memory will not be cleared an freed \, so you can change some parameters
-of the network and retrain it without having to reload the training
-dataset. Defaults to 0;
 #X text 715 225 Set a loss threshold \, where \, if the loss of the
 network is above it after training is done \, the training dataset
-memory will not be cleared an freed \, so you can change some parameters
+memory will not be cleared and freed \, so you can change some parameters
 of the network and retrain it without having to reload the training
 dataset. Defaults to FLT_MAX (3.40282e+38);
+#X text 745 335 Set an accuracy threshold \, where \, if the accuracy
+of the network is below it after training is done \, the training dataset
+memory will not be cleared and freed \, so you can change some parameters
+of the network and retrain it without having to reload the training
+dataset. Defaults to 0;
 #X restore 523 81 pd training_validating_and_predicting;
 #N canvas 170 106 1200 707 dataset_messages 0;
 #X text 176 108 ...;
-#X text 174 133 In case training or testing data are set via arrays
-in Pd \, the names of the arrays have to be set with this message.
-The number of arguments must be equal to the first argument in the
-network creation message (the number of inputs of the network);
 #X text 182 264 Similar to the "data_in_arrays" message \, only for
 output training or testing data. This message must be sent after the
 "data_in_arrays" message. The number of arguments must be equal to
@@ -170,15 +163,11 @@ data. Arguments:;
 #X text 122 473 \$1: first input datum (N);
 #X text 175 63 \$1: first input data array (N);
 #X text 175 83 $<N+1>: second input data array;
-#X text 122 494 $<N+1>: N+1 input datum (in case network has more than
-one inputs);
 #X text 121 560 $<N+2>: first output datum;
 #X text 127 592 ...;
 #X text 123 618 The total number of arguments must equal the number
 of input and output neurons of the network (the first and last argument
 of the network creation message);
-#X text 770 264 Maximum values of the inputs \, used to normalize data
-to a range from 0 to 1 or from -1 to 1 . Arguments:;
 #X text 773 305 \$1: first input datum maximum value (N);
 #X text 773 325 $<N+1>: N+1 input datum maximum value;
 #X text 775 348 ...;
@@ -194,8 +183,6 @@ data to a range from 0 to 1 or from -1 to 1 . Arguments:;
 of the network (the last argument of the network creation message)
 ;
 #X msg 623 631 shuffle_train_set;
-#X text 740 629 Shuffle the training data set (used for better fitting
-the network);
 #X msg 34 28 data_in_arrays \$1 ...;
 #X msg 34 268 data_out_arrays \$1 ...;
 #X msg 616 265 normalize_input \$1 ...;
@@ -206,19 +193,29 @@ array must be equal to the number of input neurons of the network;
 #X text 732 189 \$2: Array name for the output layer. The size of the
 array must be equal to the number of output neurons of the network
 ;
+#X msg 35 394 add [\$1] ...;
+#X text 174 133 In case training or testing data are set via arrays
+in Pd \, the names of the arrays have to be set with this message.
+The number of arguments must be equal to the first argument in the
+network creation message (the number of inputs of the network);
+#X text 123 393 Add training or testing data manually. If arrays are
+added with the "add_arrays" message (look to the right column in this
+example subpatch) \, then "add" takes no arguments. Otherwise it takes
+at least one argument. Arguments (optional):;
+#X text 122 494 $<N+1>: N+1 input datum (in case network has more than
+one input);
 #X text 732 25 This message adds arrays vertically for the input and
 output of the network (meaning \, each element of an array corresponds
 to one neuron in the input or output layer). This is usefull when all
-training or predicting data is loaded to an array in Pd \, for every
+training or prediction data is loaded to an array in Pd \, for every
 sample separately. Once this message is sent \, every time new data
 is imported \, the message "add" with no arguments must be sent \,
-and [neural_net] will read the data out of these two arrays Arguments:
+and [neuralnet] will read the data out of these two arrays Arguments:
 ;
-#X msg 35 394 add [\$1] ...;
-#X text 123 393 Add training or testing data manually. If arrays are
-added withthe "add_arrays" message (look to the right column in this
-example subpatch) \, then "add" takes no arguments. Otherwise it takes
-at least one argument. Arguments (optional):;
+#X text 770 264 Maximum values of the inputs \, used to normalize data
+to a range from 0 to 1 or from -1 to 1 Arguments:;
+#X text 740 629 Shuffle the training data set (used for better fitting
+of the network);
 #X restore 523 53 pd dataset_messages;
 #N canvas 284 184 649 623 layer_messages 0;
 #X text 242 335 "linear": Linear activation function;
@@ -246,20 +243,31 @@ the weights of the layers. Internally \, the seed is set on object
 initialization with srand(time(0)) \, but some systems may not have
 a reliable time (e.g. a Raspberry Pi that is not constantly powered)
 \, so "seed" enables setting the random seed externally;
-#X text 170 106 \$2: Dropout rate (e.g. 0.1 means 10% of neuros are
+#X text 170 106 \$2: Dropout rate (e.g. 0.1 means 10% of neurons are
 dropped in each epoch);
 #X restore 523 109 pd layer_messages;
-#N canvas 280 172 1313 678 various_netwrok_messages 0;
-#X text 186 43 create a network. arguements:;
-#X text 186 60 \$1: number of neurons in input layer;
-#X text 186 76 \$2: number of neurons in first hidden layer (N);
-#X text 186 92 \$3: if this is the last argument it is the nubmer of
+#X text 35 508 4: batch steps count (outputs during training in batches)
+;
+#X text 35 549 6: loss (outputs during training and validating);
+#X text 35 529 5: accuracy (outputs during training and validating)
+;
+#X text 35 607 Check the examples in the "examples" directory for more
+information on how to create \, train \, test \, and use various kinds
+of neural networks. Note that 02-mouse_input.pd uses [cyclone/mousestate]
+and 03-fashion_mnist.pd uses [command] and some Python scripts.;
+#X obj 37 706 neuralnet;
+#X text 37 16 [neuralnet] is an artificial neural network object that
+supports various different kinds of neural networks \, for classification
+\, regression \, and binary logistic regreassion. It is written in
+pure C and does not have any dependencies. It is based on the Python
+code from the book "Neural Networks from Scratch in Python".;
+#X text 35 205 \$3: if this is the last argument it is the number of
 neurons in the output layer \, otherwise it is the number of neurons
 in N+1 hidden layer;
+#N canvas 0 94 1280 678 various_network_messages 0;
+#X text 186 60 \$1: number of neurons in input layer;
+#X text 186 76 \$2: number of neurons in first hidden layer (N);
 #X text 186 142 ...;
-#X text 186 170 $<N+2>: number of neurons in the output layer (unless
-there are only three arguments \, in any case \, the last argument
-is sets the output layer);
 #X msg 50 490 destroy;
 #X text 105 490 destroy the network;
 #X text 184 228 for example \, the message "create 2 64 64 3" creates
@@ -297,26 +305,18 @@ will output a list with class prediction and its confidence out the
 second outlet. This is effective only when the "confidences" message
 is 0 (the network outputs a predicted class \, and not a list of confidences).
 Argument:;
-#X text 812 427 \$1: value from 0 to 1 (1 not recommended \, the netwrok
-will never output anything). Defaults to 0 (disabled);
 #X msg 679 522 set_accuracy_denominator \$1;
 #X text 869 519 Set the denominator to determine the accuracy threshold
 when in regression mode. This is defined by the standard deviation
 of the output training data \, divined by this number. Defaults to
 250;
-#X restore 523 25 pd various_netwrok_messages;
-#X text 35 508 4: batch steps count (outputs during training in batches)
-;
-#X text 35 549 6: loss (outputs during training and validating);
-#X text 35 529 5: accuracy (outputs during training and validating)
-;
-#X text 35 607 Check the examples in the "examples" directory for more
-information on how to create \, train \, test \, and use various kinds
-of neural networks. Note that 02-mouse_input.pd uses [cyclone/mousestate]
-and 03-fashion_mnist.pd uses [command] and some Python scripts.;
-#X obj 37 706 neuralnet;
-#X text 37 16 [neuralnet] is an artificial neural network object that
-supports various different kinds of neural networks \, for classification
-\, regression \, and binary logistic regreassion. It is written in
-pure C and does not have any dependencies. It is based on the Python
-code from the book "Neural Networks from Scratch in Python".;
+#X text 186 43 create a network. arguments:;
+#X text 186 92 \$3: if this is the last argument it is the number of
+neurons in the output layer \, otherwise it is the number of neurons
+in N+1 hidden layer;
+#X text 186 170 $<N+2>: number of neurons in the output layer (unless
+there are only three arguments \, in any case \, the last argument
+sets the output layer);
+#X text 812 427 \$1: value from 0 to 1 (1 not recommended \, the network
+will never output anything). Defaults to 0 (disabled);
+#X restore 523 25 pd various_network_messages;

--- a/neuralnet.c
+++ b/neuralnet.c
@@ -479,6 +479,7 @@ static void set_activation_function(t_neuralnet *x, t_symbol *s, int argc, t_ato
   int i;
   int layer;
   int found_func = 0;
+  (void)(s); /* unused */
 
   if (argc != 2) {
     pd_error(x, "set_activation_function takes 2 arguments");
@@ -1349,6 +1350,7 @@ static void create_net(t_neuralnet *x, int argc, t_atom *argv)
 
 static void create(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
+  (void)(s); /* unused */
   create_net(x, argc, argv);
 }
 
@@ -1796,6 +1798,7 @@ static void train_net(t_neuralnet *x)
 static void train(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
   int i;
+  (void)(s); /* unused */
   x->x_is_training = 1;
   x->x_is_validating = 0;
   x->x_is_predicting = 0;
@@ -1922,6 +1925,7 @@ static void set_batch_size(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
   int size = 0;
   int percentage;
+  (void)(s); /* unused */
   if (argc > 0) {
     size = (int)atom_getfloat(argv);
     if (argc > 2) {
@@ -2034,6 +2038,7 @@ static void predict(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
   int i;
   t_word *vec;
   int array_size;
+  (void)(s); /* unused */
   if (x->x_net_trained) {
     if (argc > 0) {
       if (argc != x->x_input_size) {
@@ -2809,6 +2814,7 @@ static void normalize_input(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
   int i;
   t_atom *argv_local = argv;
+  (void)(s); /* unused */
   if (argc > 0) {
     if (argc != x->x_input_size) {
       pd_error(x, "%d arguments for %d inputs", argc, x->x_input_size);
@@ -2825,6 +2831,7 @@ static void normalize_input(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 static void normalize_output(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
   int i;
+  (void)(s); /* unused */
   if (argc > 0) {
     if (argc != x->x_output_size) {
       pd_error(x, "arguments must as many as number of network inputs");
@@ -2844,6 +2851,7 @@ static void add(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
 {
   int is_one_hot = 0;
   int vert_arrays = 0;
+  (void)(s); /* unused */
   /* if we receive no arguments, it means we'll be adding arrays vertically */
   if (argc == 0) {
     if (!x->x_arrays_ver_added) {
@@ -3015,6 +3023,7 @@ static void data_in_arrays(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
   int i, j;
   t_word *vec;
   int array_size;
+  (void)(s); /* unused */
 
   if (argc != x->x_input_size) {
     pd_error(x, "number of test inputs MUST be equal to number of inputs in first layer");
@@ -3059,6 +3068,7 @@ static void data_out_arrays(t_neuralnet *x, t_symbol *s, int argc, t_atom *argv)
   int i, j, k;
   t_word *vec;
   int array_size;
+  (void)(s); /* unused */
 
   if (argc != x->x_output_size) {
     /* if we're in classification mode and the target values
@@ -3568,6 +3578,7 @@ static void init_object_variables(t_neuralnet *x)
 
 static void *neuralnet_new(t_symbol *s, int argc, t_atom *argv)
 {
+  (void)(s); /* unused */
   t_neuralnet *x = (t_neuralnet *)pd_new(neuralnet_class);
 
   /* set a random seed based on time */


### PR DESCRIPTION
This PR introduces a .gitignore file to ignore the external build files and some typo fixes in the help file and examples.

Other things I noticed:

1. neuralnet-help.pd refers to a `[pd misc-messages]` subpatch under Outlet 2, but there is no such subpatch in the file.
2. It would be helpful to include a copy of pd-lib-builder directly or the repo as a submodule/subtree to avoid requiring an additional manual install step, otherwise I suggest adding the steps necessary to clone it such as:
~~~
cd ../
git clone https://github.com/pure-data/pd-lib-builder.git
cd -
~~~
